### PR TITLE
Add readonly collection types

### DIFF
--- a/src/collections/avl_tree.rs
+++ b/src/collections/avl_tree.rs
@@ -35,7 +35,122 @@ type Ancestor = (Option<u32>, Option<Register>, u32);
 /// AVL tree struct, which is a self-balancing binary search tree. Values in the
 /// tree are stored as such the height of two sibling subtrees differ by one at
 /// most.
+///
+/// This type can be used to reference a read-only tree.
 pub struct AVLTree<
+    'a,
+    K: PartialOrd + Default + Copy + Clone + Pod + Zeroable,
+    V: Default + Copy + Clone + Pod + Zeroable,
+> {
+    /// Node allocator.
+    allocator: &'a Allocator,
+
+    /// Array of nodes to store the tree.
+    nodes: &'a [Node<K, V>],
+}
+
+impl<
+        'a,
+        K: PartialOrd + Default + Copy + Clone + Pod + Zeroable,
+        V: Default + Copy + Clone + Pod + Zeroable,
+    > AVLTree<'a, K, V>
+{
+    /// Returns the required data length (in bytes) to store a tree with the specified capacity.
+    pub const fn data_len(capacity: usize) -> usize {
+        std::mem::size_of::<Allocator>() + (capacity * std::mem::size_of::<Node<K, V>>())
+    }
+
+    /// Loads a tree from a byte array.
+    pub fn from_bytes_mut(bytes: &'a mut [u8]) -> Self {
+        let (allocator, nodes) = bytes.split_at(std::mem::size_of::<Allocator>());
+
+        let allocator = bytemuck::from_bytes::<Allocator>(allocator);
+        let nodes = bytemuck::cast_slice(nodes);
+
+        Self { allocator, nodes }
+    }
+
+    /// Returns the capacity of the tree.
+    pub fn capacity(&self) -> usize {
+        self.allocator.get_field(Field::Capacity) as usize
+    }
+
+    /// Returns the number of nodes in the tree.
+    pub fn len(&self) -> usize {
+        self.allocator.get_field(Field::Size) as usize
+    }
+
+    /// Indicates whether the tree is full or not.
+    pub fn is_full(&self) -> bool {
+        self.allocator.get_field(Field::Size) >= self.allocator.get_field(Field::Capacity)
+    }
+
+    /// Indicates whether the tree is empty or not.
+    pub fn is_empty(&self) -> bool {
+        self.allocator.get_field(Field::Size) == 0
+    }
+
+    /// Return the value under the specified key, if one is found.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - key to look up the value.
+    pub fn get(&self, key: &K) -> Option<V> {
+        self.find(key)
+            .map(|node_index| node!(self.nodes, node_index).value)
+    }
+
+    // Find the lowest entry.
+    pub fn lowest(&self) -> Option<K> {
+        let mut node = self.allocator.get_field(Field::Root);
+
+        if node == SENTINEL {
+            return None;
+        }
+
+        while node!(self.nodes, node).get_register(Register::Left) != SENTINEL {
+            node = node!(self.nodes, node).get_register(Register::Left);
+        }
+
+        Some(node!(self.nodes, node).key)
+    }
+
+    /// Checks whether a key is present in the tree or not.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - the key of the node.
+    pub fn contains(&self, key: &K) -> bool {
+        self.find(key).is_some()
+    }
+
+    fn find(&self, key: &K) -> Option<u32> {
+        let mut reference_node = self.allocator.get_field(Field::Root);
+
+        while reference_node != SENTINEL {
+            let current = node!(self.nodes, reference_node).key;
+
+            let target = if *key < current {
+                node!(self.nodes, reference_node).get_register(Register::Left)
+            } else if *key > current {
+                node!(self.nodes, reference_node).get_register(Register::Right)
+            } else {
+                return Some(reference_node);
+            };
+
+            reference_node = target;
+        }
+
+        None
+    }
+}
+
+/// AVL tree struct, which is a self-balancing binary search tree. Values in the
+/// tree are stored as such the height of two sibling subtrees differ by one at
+/// most.
+///
+/// This type can be used to reference a writable tree.
+pub struct AVLTreeMut<
     'a,
     K: PartialOrd + Default + Copy + Clone + Pod + Zeroable,
     V: Default + Copy + Clone + Pod + Zeroable,
@@ -51,7 +166,7 @@ impl<
         'a,
         K: PartialOrd + Default + Copy + Clone + Pod + Zeroable,
         V: Default + Copy + Clone + Pod + Zeroable,
-    > AVLTree<'a, K, V>
+    > AVLTreeMut<'a, K, V>
 {
     /// Returns the required data length (in bytes) to store a tree with the specified capacity.
     pub const fn data_len(capacity: usize) -> usize {
@@ -639,14 +754,14 @@ unsafe impl<
 
 #[cfg(test)]
 mod tests {
-    use crate::collections::AVLTree;
+    use crate::collections::AVLTreeMut;
 
     #[test]
     fn test_insert() {
         const CAPACITY: usize = 10;
 
-        let mut data = [0u8; AVLTree::<u64, u64>::data_len(CAPACITY)];
-        let mut tree = AVLTree::from_bytes_mut(&mut data);
+        let mut data = [0u8; AVLTreeMut::<u64, u64>::data_len(CAPACITY)];
+        let mut tree = AVLTreeMut::from_bytes_mut(&mut data);
 
         tree.allocator.initialize(CAPACITY as u32);
 
@@ -669,8 +784,8 @@ mod tests {
     fn test_large_insert() {
         const CAPACITY: usize = 10_000;
 
-        let mut data = [0u8; AVLTree::<u64, u64>::data_len(CAPACITY)];
-        let mut tree = AVLTree::from_bytes_mut(&mut data);
+        let mut data = [0u8; AVLTreeMut::<u64, u64>::data_len(CAPACITY)];
+        let mut tree = AVLTreeMut::from_bytes_mut(&mut data);
         tree.allocator.initialize(CAPACITY as u32);
 
         for i in 0..CAPACITY {
@@ -692,8 +807,8 @@ mod tests {
     fn test_large_remove() {
         const CAPACITY: usize = 10_000;
 
-        let mut data = [0u8; AVLTree::<u64, u64>::data_len(CAPACITY)];
-        let mut tree = AVLTree::from_bytes_mut(&mut data);
+        let mut data = [0u8; AVLTreeMut::<u64, u64>::data_len(CAPACITY)];
+        let mut tree = AVLTreeMut::from_bytes_mut(&mut data);
         tree.allocator.initialize(CAPACITY as u32);
 
         for i in 0..CAPACITY {
@@ -717,8 +832,8 @@ mod tests {
     fn test_large_remove_add() {
         const CAPACITY: usize = 10_000;
 
-        let mut data = [0u8; AVLTree::<u64, u64>::data_len(CAPACITY)];
-        let mut tree = AVLTree::from_bytes_mut(&mut data);
+        let mut data = [0u8; AVLTreeMut::<u64, u64>::data_len(CAPACITY)];
+        let mut tree = AVLTreeMut::from_bytes_mut(&mut data);
         tree.allocator.initialize(CAPACITY as u32);
 
         for i in 0..CAPACITY {
@@ -756,8 +871,8 @@ mod tests {
     fn test_insert_when_full() {
         const CAPACITY: usize = 10;
 
-        let mut data = [0u8; AVLTree::<u64, u64>::data_len(CAPACITY)];
-        let mut tree = AVLTree::from_bytes_mut(&mut data);
+        let mut data = [0u8; AVLTreeMut::<u64, u64>::data_len(CAPACITY)];
+        let mut tree = AVLTreeMut::from_bytes_mut(&mut data);
 
         tree.allocator.initialize(CAPACITY as u32);
 

--- a/src/collections/avl_tree.rs
+++ b/src/collections/avl_tree.rs
@@ -61,7 +61,7 @@ impl<
     }
 
     /// Loads a tree from a byte array.
-    pub fn from_bytes_mut(bytes: &'a mut [u8]) -> Self {
+    pub fn from_bytes(bytes: &'a [u8]) -> Self {
         let (allocator, nodes) = bytes.split_at(std::mem::size_of::<Allocator>());
 
         let allocator = bytemuck::from_bytes::<Allocator>(allocator);

--- a/src/collections/hash_set.rs
+++ b/src/collections/hash_set.rs
@@ -52,7 +52,7 @@ impl<'a, V: Default + Copy + Clone + Hash + PartialEq + Pod + Zeroable> HashSet<
     }
 
     /// Loads a set from a byte array.
-    pub fn from_bytes_mut(bytes: &'a [u8]) -> Self {
+    pub fn from_bytes(bytes: &'a [u8]) -> Self {
         let (allocator, nodes) = bytes.split_at(std::mem::size_of::<Allocator>());
 
         let allocator = bytemuck::from_bytes::<Allocator>(allocator);

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -2,4 +2,6 @@ pub mod avl_tree;
 pub mod hash_set;
 
 pub use avl_tree::AVLTree;
+pub use avl_tree::AVLTreeMut;
 pub use hash_set::HashSet;
+pub use hash_set::HashSetMut;


### PR DESCRIPTION
This PR adds read-only types for `AVLTree` and `HashSet`. Mutable types are now with a `Mut` suffix.